### PR TITLE
Add rockspec

### DIFF
--- a/profi-scm-1.rockspec
+++ b/profi-scm-1.rockspec
@@ -1,0 +1,20 @@
+package = "profi"
+version = "scm-1"
+source = {
+   url = "git://github.com/mindreframer/ProFi.lua",
+   dir = "ProFi.lua"
+}
+description = {
+   summary  = "A simple lua profiler that works with LuaJIT and prints a pretty report file in columns.",
+   homepage = "https://gist.github.com/perky/2838755",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ProFi = "ProFi.lua"
+   }
+}


### PR DESCRIPTION
A release version has also been added on my branch, where a tag has been created for v1.3
https://github.com/Alloyed/ProFi.lua/blob/master/profi-1.3-1.rockspec
https://github.com/Alloyed/ProFi.lua/releases/tag/v1.3
If you'd like to add a similar tag I'll make a separate PR for a version of that rockspec that points here instead (or you can do it yourself, same difference)
